### PR TITLE
Review updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021, DSCI524 Group23
+Copyright (c) 2021, Chen Zhao, Chirag Rank, and Steffen Pentelow
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Buildbadge](https://github.com/UBC-MDS/noaastn/workflows/build/badge.svg) [![codecov](https://codecov.io/gh/UBC-MDS/noaastn/branch/main/graph/badge.svg)](https://codecov.io/gh/UBC-MDS/noaastn) [![Deploy](https://github.com/UBC-MDS/noaastn/actions/workflows/deploy.yml/badge.svg)](https://github.com/UBC-MDS/noaastn/actions/workflows/deploy.yml) [![Documentation Status](https://readthedocs.org/projects/noaastn/badge/?version=latest)](https://noaastn.readthedocs.io/en/latest/?badge=latest)
 
-The US National Oceanic and Atmospheric Administration (NOAA) collects and provides access to weather data from land-based weather stations within the US and around the world ([Land-Based Station Data](https://www.ncdc.noaa.gov/data-access/land-based-station-data)).  One method for accessing these data is through a publically accessible FTP site.  This package allows users to easily download data from a given station for a given year, extract several key weather parameters from the raw data files, and visualize the variation in these parameters over time.  The weather parameters that are extracted with this package are:
+The US National Oceanic and Atmospheric Administration (NOAA) collects and provides access to weather data from land-based weather stations within the US and around the world ([Land-Based Station Data](https://www.ncdc.noaa.gov/data-access/land-based-station-data)).  One method for accessing these data is through a publicly accessible FTP site.  This package allows users to easily download data from a given station for a given year, extract several key weather parameters from the raw data files, and visualize the variation in these parameters over time.  The weather parameters that are extracted with this package are:
 
 - Air Temperature (degrees Celsius)
 - Atmospheric Pressure (hectopascals)
@@ -32,27 +32,27 @@ The list of the dependencies for this package can be viewed under
 
 ## Related Packages
 
-  There are few packages in the python ecosystem like [noaa](https://pypi.org/project/noaa/), [noaa-coops](https://pypi.org/project/noaa-coops/), [noaa-sdk](https://pypi.org/project/noaa-sdk/) that do analysis related to NOAA weather station data. These tools are more focused on using the NOAA's [API service](https://www.ncei.noaa.gov/support/access-data-service-api-user-documentation) to obtain forecast information. They do not provide an interface to obtain historical weather data from the NOAA's FTP site, process and visualize key weather parameters like this package do.
+  There are few packages in the python ecosystem like [noaa](https://pypi.org/project/noaa/), [noaa-coops](https://pypi.org/project/noaa-coops/), [noaa-sdk](https://pypi.org/project/noaa-sdk/) that do analysis related to NOAA weather station data. These tools are more focused on using the NOAA's [API service](https://www.ncei.noaa.gov/support/access-data-service-api-user-documentation) to obtain forecast information. They do not provide an interface to obtain historical weather data from the NOAA's FTP site, process and visualize key weather parameters like this package does.
 
 ## Usage
 
 Typical usage will begin with downloading the list of available weather stations in the country of interest using the `get_stations_info()` function.  A dataframe is returned which can be reviewed to find a suitable station in the area of interest.  Alternatively, the NOAA provides a [graphical interface](https://gis.ncdc.noaa.gov/maps/ncei/cdo/hourly) for exploring the available weather stations.
 
-```
+```python
 >>> from noaastn import noaastn
 >>> noaastn.get_stations_info(country = "US")
 ```
 
 ![Tabular output from get_stations_info function](https://raw.githubusercontent.com/UBC-MDS/noaastn/main/img/get_stations_info.png)
 
-After selecting a weather station number, the `get_weather_data()` function can be used to download various weather parameters for the station number and year of interest.  The following usage example downloads weather data from station number "911650-22536" for the year 2020 and saves the data to a variable called 'weather_data'.  'weather_data' will be a data frame containing a time series of the following parameters for the station and year of interest:
+After selecting a weather station number, the `get_weather_data()` function can be used to download various weather parameters for the station number and year of interest.  NOAA stations are specified using two ID codes: the USAF station ID and the NCDC WBAN number.  The `station_number` argument must have the form '<USAF ID>-<WBAN ID>', both of which can be found in the table returned by `get_stations_info()` (if a WBAN ID does not exist, a value of '99999' should be used in its place).  The following usage example downloads weather data from station number "911650-22536" for the year 2020 and saves the data to a variable called 'weather_data'.  'weather_data' will be a data frame containing a time series of the following parameters for the station and year of interest:
 
 - air temperature (degrees Celsius)
 - atmospheric pressure (hectopascals)
 - wind speed (m/s)
 - wind direction (angular degrees)
 
-```
+```python
 >>> weather_data = noaastn.get_weather_data("911650-22536", 2020)
 >>> print(weather_data)
 ```
@@ -61,7 +61,7 @@ After selecting a weather station number, the `get_weather_data()` function can 
 
 The function `plot_weather_data()` can be used to visualize a time series of any of the available weather parameters either on a mean daily or mean monthly basis.  The function returns an Altair chart object which can be saved or displayed in any environment which can render Altair objects.
 
-```
+```python
 >>> noaastn.plot_weather_data(weather_data, col_name="air_temp", time_basis="monthly")
 ```
 
@@ -73,7 +73,7 @@ Documentation for this package can be found on [Read the Docs](https://noaastn.r
 
 ## Contributors
 
-We welcome and recognize all contributions. You can see a list of current contributors in the [contributors tab](https://github.com/UBC-MDS/noaastn/graphs/contributors).
+We welcome and recognize all contributions. You can see a list of current contributors in the [contributors tab](https://github.com/UBC-MDS/noaastn/graphs/contributors).  The package was originally developed by Chen Zhao, Chirag Rank, and Steffen Pentelow.
 
 ## Credits
 

--- a/noaastn/noaastn.py
+++ b/noaastn/noaastn.py
@@ -137,7 +137,7 @@ def get_weather_data(station_number, year):
         type(station_number) == str
     ), "Station number must be entered as a string"
     assert re.match(
-        "^[0-9]{6}[-][0-9]{5}$", station_number
+        "^[A-z|0-9][0-9]{5}[-][0-9]{5}$", station_number
     ), 'Station number must be entered in form "911650-22536".'
 
     # Generate filename based on selected station number and year and download

--- a/noaastn/noaastn.py
+++ b/noaastn/noaastn.py
@@ -154,7 +154,7 @@ def get_weather_data(station_number, year):
     except error_perm as e_mess:
         print("Error generated from NOAA FTP site: \n", e_mess)
         noaa_ftp.quit()
-        return 'FTP Error'
+        return
 
     noaa_ftp.quit()
 

--- a/tests/test_get_weather_data.py
+++ b/tests/test_get_weather_data.py
@@ -48,6 +48,6 @@ def test_station_number_coding():
 
 def test_ftp_error_handling():
     assert (
-        noaastn.get_weather_data("999999-99999", 1750) == "FTP Error"
-    ), """Entry of invalid station/year combination should return string
-    'FTP error'."""
+        not noaastn.get_weather_data("999999-99999", 1750)
+    ), """Entry of invalid station/year combination should not return 
+    anything."""

--- a/tests/test_get_weather_data.py
+++ b/tests/test_get_weather_data.py
@@ -49,5 +49,5 @@ def test_station_number_coding():
 def test_ftp_error_handling():
     assert (
         not noaastn.get_weather_data("999999-99999", 1750)
-    ), """Entry of invalid station/year combination should not return 
+    ), """Entry of invalid station/year combination should not return
     anything."""


### PR DESCRIPTION
Addressed various changes from Marco and Chad's reviews:

- Marco:
  - Changed regex in assert statement in `get_weather_data()` fxn to allow station numbers that begin with a letter
  - Added group member names explicitly to Contributors section of readme
  - Fixed readme typo ('do' to 'does')
  - Changed code chunk format to be ```python in readme

- Chad:
  - Clarified meaning/format of `station_number` argument of `get_weather_data()` function in the usage section of the readme
  - Fixed readme typo ('publically' to 'publicly')
  - Added group member names explicitly to Contributors section of readme
  - Changed error thrown when a year is entered for which there is no station data (removed 'FTP Error' return).  Although the suggestion of checking the year/station_id combination entered in the `get_weather_data()` function against the output table from `get_stations_info()` is a good one, it has not been implemented.  To implement it would mean calling `get_stations_info()` from within the `get_weather_data()` function and I think that the loss in performance is not worth the gain in being able to explicitly check the user input.  The revised error raised by the function if an year is entered for which there is no data is shown below and, while not ideal, is descriptive enough at this stage.
```
> Error generated from NOAA FTP site: 
> 550 911650-22536-1970.gz: No such file or directory
```